### PR TITLE
Fix issue with py27 environs for importing a module from a module with same name

### DIFF
--- a/politicalplaces/backends/googlemaps.py
+++ b/politicalplaces/backends/googlemaps.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from googlemaps import Client as GmapsClient
 from django.conf import settings
 


### PR DESCRIPTION
it uses "from __future__ import absolute_import" to enable same default behavior of importing modules in Python 3